### PR TITLE
adjustments to NTLM LDAP support

### DIFF
--- a/lib/rex/proto/ldap/server.rb
+++ b/lib/rex/proto/ldap/server.rb
@@ -261,7 +261,7 @@ module Rex
           ]
 
           if context_data && context_code
-            tag_sequence << [context_data.to_ber].to_ber_contextspecific(context_code)
+            tag_sequence << context_data.to_ber_contextspecific(context_code)
           end
 
           [

--- a/modules/auxiliary/server/capture/ldap.rb
+++ b/modules/auxiliary/server/capture/ldap.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def primer
     service.processed_pdu_handler(Net::LDAP::PDU::BindRequest) do |processed_data|
-      unless processed_data[:post_pdu]
+      if processed_data[:post_pdu]
         if processed_data[:error_msg]
           print_error(processed_data[:error_msg])
         else

--- a/spec/lib/rex/proto/ldap/auth_spec.rb
+++ b/spec/lib/rex/proto/ldap/auth_spec.rb
@@ -26,7 +26,14 @@ RSpec.describe Rex::Proto::LDAP::Auth do
 
   let(:user_login) { OpenStruct.new }
   let(:ntlm_type1) do
-    type1 = "0K\x02\x01\x01`F\x02\x01\x03\x04\x00\xA3?\x04\nGSS-SPNEGO\x041NTLMSSP\x00\x01\x00\x00\x00\x05\x82\x88B\x06\x00\x06\x00 \x00\x00\x00\v\x00\v\x00&\x00\x00\x00DOMAINWORKSTATION".read_ber(Net::LDAP::AsnSyntax)
+    ntlm1 = Net::NTLM::Message::Type1.new.serialize
+
+    sasl = ['GSS-SPNEGO'.to_ber, ntlm1.to_ber].to_ber_contextspecific(3)
+    br = [
+      Net::LDAP::Connection::LdapVersion.to_ber, ''.to_ber, sasl
+    ].to_ber_appsequence(Net::LDAP::PDU::BindRequest)
+
+    type1 = [0.to_ber, br, nil].compact.to_ber_sequence.read_ber(Net::LDAP::AsnSyntax)
     pdu = Net::LDAP::PDU.new(type1)
     pdu.bind_parameters
   end


### PR DESCRIPTION
Adjustments based on PR review and testing

* invert storage test for callback
* do not override service instance domain and hostname
* remove wrapping `Array` on `context_data` in response
* generate NTLM Type1 message instead of hardcoded blob